### PR TITLE
Abort on first error

### DIFF
--- a/setup-network.sh
+++ b/setup-network.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -e
 
 # Author: Pankaj Shelare
 # Email: pankaj.shelare@gmail.com


### PR DESCRIPTION
Script runs with no problems after adding `set -e`. This change makes it abort when it encounters an error (i.e. when a command returns a non-zero code).

Closes #8