### PR TITLE
Fixed issue #12 valid country code refused

### DIFF
--- a/setup-network.sh
+++ b/setup-network.sh
@@ -93,8 +93,8 @@ function setWlanDetails()
 {
     # Set Country Code:
     wlanCountryCode="$( cat /etc/wpa_supplicant/wpa_supplicant.conf | grep -i 'country=' | awk -F '=' '{print $2}' )"
-    # FIX: #12, trimming spaces for WLAN Country code if there are any.
-    wlanCountryCode="$( echo $wlanCountryCode )"
+    # FIX: #12, trimming spaces and carriage return for WLAN Country code if there are any.
+    wlanCountryCode="$( echo $wlanCountryCode | tr -d '\r' )"
     if [[ ! -z "${wlanCountryCode}" && \
 	("${countryCodeArray[@]}" =~ "${wlanCountryCode}") ]]; then
 	apCountryCode="$wlanCountryCode"


### PR DESCRIPTION
Fixes #12 

Issues occurs if `/etc/wpa_supplicant/wpa_supplicant.conf` contains carriage returns.
For example if it was edited or created during headless setup on Windows.

When retrieving country code:
```sh
wlanCountryCode="$( cat /etc/wpa_supplicant/wpa_supplicant.conf | grep -i 'country=' | awk -F '=' '{print $2}' )"
```
carriage return `\r` is kept in the `wlanCountryCode` variable, making checks fail when compared to `--ap-country-code` parameter:
```sh
if [ ! -z "$apCountryCodeTemp" ]; then
	if [[ "${countryCodeArray[@]}" =~ "${apCountryCodeTemp}" ]]; then
		if [[ ! -z "${wlanCountryCode}" && \
			(( ! "${countryCodeArray[@]}" =~ "${wlanCountryCode}") || \ # TRUE
			( ! "${apCountryCodeTemp}" =~ "${wlanCountryCode}")) ]]; then # TRUE
			apCountryCodeValid=false # Country code is considered invalid
		else
			apCountryCodeValid=true
			apCountryCode="$apCountryCodeTemp"
		fi
	else
		apCountryCodeValid=false
	fi
fi

```